### PR TITLE
Lecture-5-Sympy: Add missing verb 'use'

### DIFF
--- a/Lecture-5-Sympy.ipynb
+++ b/Lecture-5-Sympy.ipynb
@@ -955,7 +955,7 @@
      "source": [
       "## apart and together\n",
       "\n",
-      "To manipulate symbolic expressions of fractions, we can the `apart` and `together` functions:"
+      "To manipulate symbolic expressions of fractions, we can use the `apart` and `together` functions:"
      ]
     },
     {


### PR DESCRIPTION
Replace 'we can the' with 'we can use the'
