### PR TITLE
typo ('altas blas' --> 'atlas blas')

### DIFF
--- a/Lecture-0-Scientific-Computing-with-Python.ipynb
+++ b/Lecture-0-Scientific-Computing-with-Python.ipynb
@@ -185,7 +185,7 @@
     "    * matplotlib: http://www.matplotlib.org - graphics library\n",
     "\n",
     "* Great performance due to close integration with time-tested and highly optimized codes written in C and Fortran:\n",
-    "    * blas, altas blas, lapack, arpack, Intel MKL, ...\n",
+    "    * blas, atlas blas, lapack, arpack, Intel MKL, ...\n",
     "\n",
     "* Good support for \n",
     "    * Parallel processing with processes and threads\n",


### PR DESCRIPTION
just a tiny typo correction