### PR TITLE
Fix incorrectly rendered shell code blocks in markdown

### DIFF
--- a/Lecture-0-Scientific-Computing-with-Python.ipynb
+++ b/Lecture-0-Scientific-Computing-with-Python.ipynb
@@ -298,7 +298,9 @@
     "\n",
     "Although using a web browser as graphical interface, IPython notebooks are usually run locally, from the same computer that run the browser. To start a new IPython notebook session, run the following command:\n",
     "\n",
-    "    $ ipython notebook\n",
+    "```\n",
+    "$ ipython notebook\n",
+    "```\n",
     "\n",
     "from a directory where you want the notebooks to be stored. This will open a new browser window (or a new tab in an existing window) with an index page where existing notebooks are shown and from which new notebooks can be created."
    ]
@@ -340,12 +342,12 @@
     "There are currently two versions of python: Python 2 and Python 3. Python 3 will eventually supercede Python 2, but it is not backward-compatible with Python 2. A lot of existing python code and packages has been written for Python 2, and it is still the most wide-spread version. For these lectures either version will be fine, but it is probably easier to stick with Python 2 for now, because it is more readily available via prebuilt packages and binary installers.\n",
     "\n",
     "To see which version of Python you have, run\n",
-    "    \n",
-    "    $ python --version\n",
-    "    Python 2.7.3\n",
-    "    $ python3.2 --version\n",
-    "    Python 3.2.3\n",
-    "\n",
+    "```\n",
+    "$ python --version\n",
+    "Python 2.7.3\n",
+    "$ python3.2 --version\n",
+    "Python 3.2.3\n",
+    "```\n",
     "Several versions of Python can be installed in parallel, as shown above.\n"
    ]
   },
@@ -369,7 +371,9 @@
    "source": [
     "The best way set-up an scientific Python environment is to use the cross-platform package manager `conda` from Continuum Analytics. First download and install miniconda http://conda.pydata.org/miniconda.html or Anaconda (see below). Next, to install the required libraries for these notebooks, simply run:\n",
     "\n",
-    "    $ conda install ipython ipython-notebook spyder numpy scipy sympy matplotlib cython\n",
+    "```\n",
+    "$ conda install ipython ipython-notebook spyder numpy scipy sympy matplotlib cython\n",
+    "```\n",
     "\n",
     "This should be sufficient to get a working environment on any platform supported by `conda`."
    ]
@@ -387,9 +391,11 @@
    "source": [
     "In Ubuntu Linux, to installing python and all the requirements run:\n",
     "\n",
-    "    $ sudo apt-get install python ipython ipython-notebook\n",
+    "```\n",
+    "$ sudo apt-get install python ipython ipython-notebook\n",
     "$ sudo apt-get install python-numpy python-scipy python-matplotlib python-sympy\n",
-    "    $ sudo apt-get install spyder"
+    "$ sudo apt-get install spyder\n",
+    "```"
    ]
   },
   {
@@ -407,21 +413,27 @@
     "\n",
     "Python is included by default in Mac OS X, but for our purposes it will be useful to install a new python environment using [Macports](http://www.macports.org/), because it makes it much easier to install all the required additional packages. Using Macports, we can install what we need with:\n",
     "\n",
-    "    $ sudo port install py27-ipython +pyside+notebook+parallel+scientific\n",
-    "    $ sudo port install py27-scipy py27-matplotlib py27-sympy\n",
-    "    $ sudo port install py27-spyder\n",
+    "```\n",
+    "$ sudo port install py27-ipython +pyside+notebook+parallel+scientific\n",
+    "$ sudo port install py27-scipy py27-matplotlib py27-sympy\n",
+    "$ sudo port install py27-spyder\n",
+    "```\n",
     "\n",
     "These will associate the commands `python` and `ipython` with the versions installed via macports (instead of the one that is shipped with Mac OS X), run the following commands:\n",
     "\n",
-    "    $ sudo port select python python27\n",
-    "    $ sudo port select ipython ipython27\n",
+    "```\n",
+    "$ sudo port select python python27\n",
+    "$ sudo port select ipython ipython27\n",
+    "```\n",
     "\n",
     "*Fink*\n",
     "\n",
     "Or, alternatively, you can use the [Fink](http://www.finkproject.org/) package manager. After installing Fink, use the following command to install python and the packages that we need:\n",
     "\n",
-    "    $ sudo fink install python27 ipython-py27 numpy-py27 matplotlib-py27 scipy-py27 sympy-py27\n",
-    "    $ sudo fink install spyder-mac-py27"
+    "```\n",
+    "$ sudo fink install python27 ipython-py27 numpy-py27 matplotlib-py27 scipy-py27 sympy-py27\n",
+    "$ sudo fink install spyder-mac-py27\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
The linux installation instructions were broken. The problem might also occur in the other lectures.