### PR TITLE
Numba

### DIFF
--- a/Lecture-6A-Fortran-Numba-and-C.ipynb
+++ b/Lecture-6A-Fortran-Numba-and-C.ipynb
@@ -148,8 +148,8 @@
       "\u001b[39mbuild_src\u001b[0m\n",
       "\u001b[39mbuilding extension \"hellofortran\" sources\u001b[0m\n",
       "\u001b[39mf2py options: []\u001b[0m\n",
-      "\u001b[39mf2py:> /tmp/tmpz2IPjB/src.linux-x86_64-2.7/hellofortranmodule.c\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpz2IPjB/src.linux-x86_64-2.7\u001b[0m\n",
+      "\u001b[39mf2py:> /tmp/tmp3kn12pr2/src.linux-x86_64-3.6/hellofortranmodule.c\u001b[0m\n",
+      "\u001b[39mcreating /tmp/tmp3kn12pr2/src.linux-x86_64-3.6\u001b[0m\n",
       "Reading fortran codes...\n",
       "\tReading file 'hellofortran.f' (format:fix,strict)\n",
       "Post-processing...\n",
@@ -160,53 +160,54 @@
       "\tBuilding module \"hellofortran\"...\n",
       "\t\tConstructing wrapper function \"hellofortran\"...\n",
       "\t\t  hellofortran(n)\n",
-      "\tWrote C/API module \"hellofortran\" to file \"/tmp/tmpz2IPjB/src.linux-x86_64-2.7/hellofortranmodule.c\"\n",
-      "\u001b[39m  adding '/tmp/tmpz2IPjB/src.linux-x86_64-2.7/fortranobject.c' to sources.\u001b[0m\n",
-      "\u001b[39m  adding '/tmp/tmpz2IPjB/src.linux-x86_64-2.7' to include_dirs.\u001b[0m\n",
-      "\u001b[39mcopying /usr/lib/python2.7/dist-packages/numpy/f2py/src/fortranobject.c -> /tmp/tmpz2IPjB/src.linux-x86_64-2.7\u001b[0m\n",
-      "\u001b[39mcopying /usr/lib/python2.7/dist-packages/numpy/f2py/src/fortranobject.h -> /tmp/tmpz2IPjB/src.linux-x86_64-2.7\u001b[0m\n",
+      "\tWrote C/API module \"hellofortran\" to file \"/tmp/tmp3kn12pr2/src.linux-x86_64-3.6/hellofortranmodule.c\"\n",
+      "\u001b[39m  adding '/tmp/tmp3kn12pr2/src.linux-x86_64-3.6/fortranobject.c' to sources.\u001b[0m\n",
+      "\u001b[39m  adding '/tmp/tmp3kn12pr2/src.linux-x86_64-3.6' to include_dirs.\u001b[0m\n",
+      "\u001b[39mcopying /usr/local/lib/python3.6/dist-packages/numpy/f2py/src/fortranobject.c -> /tmp/tmp3kn12pr2/src.linux-x86_64-3.6\u001b[0m\n",
+      "\u001b[39mcopying /usr/local/lib/python3.6/dist-packages/numpy/f2py/src/fortranobject.h -> /tmp/tmp3kn12pr2/src.linux-x86_64-3.6\u001b[0m\n",
       "\u001b[39mbuild_src: building npy-pkg config files\u001b[0m\n",
       "\u001b[39mrunning build_ext\u001b[0m\n",
       "\u001b[39mcustomize UnixCCompiler\u001b[0m\n",
       "\u001b[39mcustomize UnixCCompiler using build_ext\u001b[0m\n",
+      "\u001b[39mget_default_fcompiler: matching types: '['gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq', 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor']'\u001b[0m\n",
       "\u001b[39mcustomize Gnu95FCompiler\u001b[0m\n",
       "\u001b[39mFound executable /usr/bin/gfortran\u001b[0m\n",
       "\u001b[39mcustomize Gnu95FCompiler\u001b[0m\n",
       "\u001b[39mcustomize Gnu95FCompiler using build_ext\u001b[0m\n",
       "\u001b[39mbuilding 'hellofortran' extension\u001b[0m\n",
       "\u001b[39mcompiling C sources\u001b[0m\n",
-      "\u001b[39mC compiler: x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC\n",
+      "\u001b[39mC compiler: x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fdebug-prefix-map=/build/python3.6-sXpGnM/python3.6-3.6.3=. -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC\n",
       "\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpz2IPjB/tmp\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpz2IPjB/tmp/tmpz2IPjB\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpz2IPjB/tmp/tmpz2IPjB/src.linux-x86_64-2.7\u001b[0m\n",
-      "\u001b[39mcompile options: '-I/tmp/tmpz2IPjB/src.linux-x86_64-2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/include/python2.7 -c'\u001b[0m\n",
-      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmpz2IPjB/src.linux-x86_64-2.7/hellofortranmodule.c\u001b[0m\n",
-      "In file included from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarrayobject.h:17,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
-      "                 from /tmp/tmpz2IPjB/src.linux-x86_64-2.7/fortranobject.h:13,\n",
-      "                 from /tmp/tmpz2IPjB/src.linux-x86_64-2.7/hellofortranmodule.c:17:\n",
-      "/usr/lib/python2.7/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
+      "\u001b[39mcreating /tmp/tmp3kn12pr2/tmp\u001b[0m\n",
+      "\u001b[39mcreating /tmp/tmp3kn12pr2/tmp/tmp3kn12pr2\u001b[0m\n",
+      "\u001b[39mcreating /tmp/tmp3kn12pr2/tmp/tmp3kn12pr2/src.linux-x86_64-3.6\u001b[0m\n",
+      "\u001b[39mcompile options: '-I/tmp/tmp3kn12pr2/src.linux-x86_64-3.6 -I/usr/local/lib/python3.6/dist-packages/numpy/core/include -I/usr/include/python3.6m -c'\u001b[0m\n",
+      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmp3kn12pr2/src.linux-x86_64-3.6/hellofortranmodule.c\u001b[0m\n",
+      "In file included from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1816:0,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarrayobject.h:18,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
+      "                 from /tmp/tmp3kn12pr2/src.linux-x86_64-3.6/fortranobject.h:13,\n",
+      "                 from /tmp/tmp3kn12pr2/src.linux-x86_64-3.6/hellofortranmodule.c:15:\n",
+      "/usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
       " #warning \"Using deprecated NumPy API, disable it by \" \\\n",
-      "  ^\n",
-      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmpz2IPjB/src.linux-x86_64-2.7/fortranobject.c\u001b[0m\n",
-      "In file included from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarrayobject.h:17,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
-      "                 from /tmp/tmpz2IPjB/src.linux-x86_64-2.7/fortranobject.h:13,\n",
-      "                 from /tmp/tmpz2IPjB/src.linux-x86_64-2.7/fortranobject.c:2:\n",
-      "/usr/lib/python2.7/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
+      "  ^~~~~~~\n",
+      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmp3kn12pr2/src.linux-x86_64-3.6/fortranobject.c\u001b[0m\n",
+      "In file included from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1816:0,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarrayobject.h:18,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
+      "                 from /tmp/tmp3kn12pr2/src.linux-x86_64-3.6/fortranobject.h:13,\n",
+      "                 from /tmp/tmp3kn12pr2/src.linux-x86_64-3.6/fortranobject.c:2:\n",
+      "/usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
       " #warning \"Using deprecated NumPy API, disable it by \" \\\n",
-      "  ^\n",
+      "  ^~~~~~~\n",
       "\u001b[39mcompiling Fortran sources\u001b[0m\n",
-      "\u001b[39mFortran f77 compiler: /usr/bin/gfortran -Wall -ffixed-form -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-      "Fortran f90 compiler: /usr/bin/gfortran -Wall -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-      "Fortran fix compiler: /usr/bin/gfortran -Wall -ffixed-form -fno-second-underscore -Wall -fno-second-underscore -fPIC -O3 -funroll-loops\u001b[0m\n",
-      "\u001b[39mcompile options: '-I/tmp/tmpz2IPjB/src.linux-x86_64-2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/include/python2.7 -c'\u001b[0m\n",
+      "\u001b[39mFortran f77 compiler: /usr/bin/gfortran -Wall -g -ffixed-form -fno-second-underscore -fPIC -O3 -funroll-loops\n",
+      "Fortran f90 compiler: /usr/bin/gfortran -Wall -g -fno-second-underscore -fPIC -O3 -funroll-loops\n",
+      "Fortran fix compiler: /usr/bin/gfortran -Wall -g -ffixed-form -fno-second-underscore -Wall -g -fno-second-underscore -fPIC -O3 -funroll-loops\u001b[0m\n",
+      "\u001b[39mcompile options: '-I/tmp/tmp3kn12pr2/src.linux-x86_64-3.6 -I/usr/local/lib/python3.6/dist-packages/numpy/core/include -I/usr/include/python3.6m -c'\u001b[0m\n",
       "\u001b[39mgfortran:f77: hellofortran.f\u001b[0m\n",
-      "\u001b[39m/usr/bin/gfortran -Wall -Wall -shared /tmp/tmpz2IPjB/tmp/tmpz2IPjB/src.linux-x86_64-2.7/hellofortranmodule.o /tmp/tmpz2IPjB/tmp/tmpz2IPjB/src.linux-x86_64-2.7/fortranobject.o /tmp/tmpz2IPjB/hellofortran.o -lgfortran -o ./hellofortran.so\u001b[0m\n",
-      "Removing build directory /tmp/tmpz2IPjB\n"
+      "\u001b[39m/usr/bin/gfortran -Wall -g -Wall -g -shared /tmp/tmp3kn12pr2/tmp/tmp3kn12pr2/src.linux-x86_64-3.6/hellofortranmodule.o /tmp/tmp3kn12pr2/tmp/tmp3kn12pr2/src.linux-x86_64-3.6/fortranobject.o /tmp/tmp3kn12pr2/hellofortran.o -L/usr/lib/gcc/x86_64-linux-gnu/7 -L/usr/lib/gcc/x86_64-linux-gnu/7 -lgfortran -o ./hellofortran.cpython-36m-x86_64-linux-gnu.so\u001b[0m\n",
+      "Removing build directory /tmp/tmp3kn12pr2\n"
      ]
     }
    ],
@@ -335,9 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -422,7 +421,7 @@
       "\u001b[39mrunning build_src\u001b[0m\n",
       "\u001b[39mbuild_src\u001b[0m\n",
       "\u001b[39mbuilding extension \"dprod\" sources\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpWyCvx1/src.linux-x86_64-2.7\u001b[0m\n",
+      "\u001b[39mcreating /tmp/tmpmpxoinm3/src.linux-x86_64-3.6\u001b[0m\n",
       "\u001b[39mf2py options: []\u001b[0m\n",
       "\u001b[39mf2py: dprod.pyf\u001b[0m\n",
       "Reading fortran codes...\n",
@@ -435,56 +434,57 @@
       "\tBuilding module \"dprod\"...\n",
       "\t\tConstructing wrapper function \"dprod\"...\n",
       "\t\t  y = dprod(x,[n])\n",
-      "\tWrote C/API module \"dprod\" to file \"/tmp/tmpWyCvx1/src.linux-x86_64-2.7/dprodmodule.c\"\n",
-      "\u001b[39m  adding '/tmp/tmpWyCvx1/src.linux-x86_64-2.7/fortranobject.c' to sources.\u001b[0m\n",
-      "\u001b[39m  adding '/tmp/tmpWyCvx1/src.linux-x86_64-2.7' to include_dirs.\u001b[0m\n",
-      "\u001b[39mcopying /usr/lib/python2.7/dist-packages/numpy/f2py/src/fortranobject.c -> /tmp/tmpWyCvx1/src.linux-x86_64-2.7\u001b[0m\n",
-      "\u001b[39mcopying /usr/lib/python2.7/dist-packages/numpy/f2py/src/fortranobject.h -> /tmp/tmpWyCvx1/src.linux-x86_64-2.7\u001b[0m\n",
+      "\tWrote C/API module \"dprod\" to file \"/tmp/tmpmpxoinm3/src.linux-x86_64-3.6/dprodmodule.c\"\n",
+      "\u001b[39m  adding '/tmp/tmpmpxoinm3/src.linux-x86_64-3.6/fortranobject.c' to sources.\u001b[0m\n",
+      "\u001b[39m  adding '/tmp/tmpmpxoinm3/src.linux-x86_64-3.6' to include_dirs.\u001b[0m\n",
+      "\u001b[39mcopying /usr/local/lib/python3.6/dist-packages/numpy/f2py/src/fortranobject.c -> /tmp/tmpmpxoinm3/src.linux-x86_64-3.6\u001b[0m\n",
+      "\u001b[39mcopying /usr/local/lib/python3.6/dist-packages/numpy/f2py/src/fortranobject.h -> /tmp/tmpmpxoinm3/src.linux-x86_64-3.6\u001b[0m\n",
       "\u001b[39mbuild_src: building npy-pkg config files\u001b[0m\n",
       "\u001b[39mrunning build_ext\u001b[0m\n",
       "\u001b[39mcustomize UnixCCompiler\u001b[0m\n",
       "\u001b[39mcustomize UnixCCompiler using build_ext\u001b[0m\n",
+      "\u001b[39mget_default_fcompiler: matching types: '['gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq', 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor']'\u001b[0m\n",
       "\u001b[39mcustomize Gnu95FCompiler\u001b[0m\n",
       "\u001b[39mFound executable /usr/bin/gfortran\u001b[0m\n",
       "\u001b[39mcustomize Gnu95FCompiler\u001b[0m\n",
       "\u001b[39mcustomize Gnu95FCompiler using build_ext\u001b[0m\n",
       "\u001b[39mbuilding 'dprod' extension\u001b[0m\n",
       "\u001b[39mcompiling C sources\u001b[0m\n",
-      "\u001b[39mC compiler: x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC\n",
+      "\u001b[39mC compiler: x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fdebug-prefix-map=/build/python3.6-sXpGnM/python3.6-3.6.3=. -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC\n",
       "\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpWyCvx1/tmp\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpWyCvx1/tmp/tmpWyCvx1\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpWyCvx1/tmp/tmpWyCvx1/src.linux-x86_64-2.7\u001b[0m\n",
-      "\u001b[39mcompile options: '-I/tmp/tmpWyCvx1/src.linux-x86_64-2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/include/python2.7 -c'\u001b[0m\n",
-      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmpWyCvx1/src.linux-x86_64-2.7/dprodmodule.c\u001b[0m\n",
-      "In file included from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarrayobject.h:17,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
-      "                 from /tmp/tmpWyCvx1/src.linux-x86_64-2.7/fortranobject.h:13,\n",
-      "                 from /tmp/tmpWyCvx1/src.linux-x86_64-2.7/dprodmodule.c:18:\n",
-      "/usr/lib/python2.7/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
+      "\u001b[39mcreating /tmp/tmpmpxoinm3/tmp\u001b[0m\n",
+      "\u001b[39mcreating /tmp/tmpmpxoinm3/tmp/tmpmpxoinm3\u001b[0m\n",
+      "\u001b[39mcreating /tmp/tmpmpxoinm3/tmp/tmpmpxoinm3/src.linux-x86_64-3.6\u001b[0m\n",
+      "\u001b[39mcompile options: '-I/tmp/tmpmpxoinm3/src.linux-x86_64-3.6 -I/usr/local/lib/python3.6/dist-packages/numpy/core/include -I/usr/include/python3.6m -c'\u001b[0m\n",
+      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmpmpxoinm3/src.linux-x86_64-3.6/dprodmodule.c\u001b[0m\n",
+      "In file included from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1816:0,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarrayobject.h:18,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
+      "                 from /tmp/tmpmpxoinm3/src.linux-x86_64-3.6/fortranobject.h:13,\n",
+      "                 from /tmp/tmpmpxoinm3/src.linux-x86_64-3.6/dprodmodule.c:16:\n",
+      "/usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
       " #warning \"Using deprecated NumPy API, disable it by \" \\\n",
-      "  ^\n",
-      "/tmp/tmpWyCvx1/src.linux-x86_64-2.7/dprodmodule.c:111:12: warning: ‘f2py_size’ defined but not used [-Wunused-function]\n",
+      "  ^~~~~~~\n",
+      "/tmp/tmpmpxoinm3/src.linux-x86_64-3.6/dprodmodule.c:109:12: warning: ‘f2py_size’ defined but not used [-Wunused-function]\n",
       " static int f2py_size(PyArrayObject* var, ...)\n",
-      "            ^\n",
-      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmpWyCvx1/src.linux-x86_64-2.7/fortranobject.c\u001b[0m\n",
-      "In file included from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarrayobject.h:17,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
-      "                 from /tmp/tmpWyCvx1/src.linux-x86_64-2.7/fortranobject.h:13,\n",
-      "                 from /tmp/tmpWyCvx1/src.linux-x86_64-2.7/fortranobject.c:2:\n",
-      "/usr/lib/python2.7/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
+      "            ^~~~~~~~~\n",
+      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmpmpxoinm3/src.linux-x86_64-3.6/fortranobject.c\u001b[0m\n",
+      "In file included from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1816:0,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarrayobject.h:18,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
+      "                 from /tmp/tmpmpxoinm3/src.linux-x86_64-3.6/fortranobject.h:13,\n",
+      "                 from /tmp/tmpmpxoinm3/src.linux-x86_64-3.6/fortranobject.c:2:\n",
+      "/usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
       " #warning \"Using deprecated NumPy API, disable it by \" \\\n",
-      "  ^\n",
+      "  ^~~~~~~\n",
       "\u001b[39mcompiling Fortran sources\u001b[0m\n",
-      "\u001b[39mFortran f77 compiler: /usr/bin/gfortran -Wall -ffixed-form -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-      "Fortran f90 compiler: /usr/bin/gfortran -Wall -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-      "Fortran fix compiler: /usr/bin/gfortran -Wall -ffixed-form -fno-second-underscore -Wall -fno-second-underscore -fPIC -O3 -funroll-loops\u001b[0m\n",
-      "\u001b[39mcompile options: '-I/tmp/tmpWyCvx1/src.linux-x86_64-2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/include/python2.7 -c'\u001b[0m\n",
+      "\u001b[39mFortran f77 compiler: /usr/bin/gfortran -Wall -g -ffixed-form -fno-second-underscore -fPIC -O3 -funroll-loops\n",
+      "Fortran f90 compiler: /usr/bin/gfortran -Wall -g -fno-second-underscore -fPIC -O3 -funroll-loops\n",
+      "Fortran fix compiler: /usr/bin/gfortran -Wall -g -ffixed-form -fno-second-underscore -Wall -g -fno-second-underscore -fPIC -O3 -funroll-loops\u001b[0m\n",
+      "\u001b[39mcompile options: '-I/tmp/tmpmpxoinm3/src.linux-x86_64-3.6 -I/usr/local/lib/python3.6/dist-packages/numpy/core/include -I/usr/include/python3.6m -c'\u001b[0m\n",
       "\u001b[39mgfortran:f77: dprod.f\u001b[0m\n",
-      "\u001b[39m/usr/bin/gfortran -Wall -Wall -shared /tmp/tmpWyCvx1/tmp/tmpWyCvx1/src.linux-x86_64-2.7/dprodmodule.o /tmp/tmpWyCvx1/tmp/tmpWyCvx1/src.linux-x86_64-2.7/fortranobject.o /tmp/tmpWyCvx1/dprod.o -lgfortran -o ./dprod.so\u001b[0m\n",
-      "Removing build directory /tmp/tmpWyCvx1\n"
+      "\u001b[39m/usr/bin/gfortran -Wall -g -Wall -g -shared /tmp/tmpmpxoinm3/tmp/tmpmpxoinm3/src.linux-x86_64-3.6/dprodmodule.o /tmp/tmpmpxoinm3/tmp/tmpmpxoinm3/src.linux-x86_64-3.6/fortranobject.o /tmp/tmpmpxoinm3/dprod.o -L/usr/lib/gcc/x86_64-linux-gnu/7 -L/usr/lib/gcc/x86_64-linux-gnu/7 -lgfortran -o ./dprod.cpython-36m-x86_64-linux-gnu.so\u001b[0m\n",
+      "Removing build directory /tmp/tmpmpxoinm3\n"
      ]
     }
    ],
@@ -522,9 +522,6 @@
       "NAME\n",
       "    dprod\n",
       "\n",
-      "FILE\n",
-      "    /home/rob/Desktop/scientific-python-lectures/dprod.so\n",
-      "\n",
       "DESCRIPTION\n",
       "    This module 'dprod' is auto-generated with f2py (version:2).\n",
       "    Functions:\n",
@@ -532,11 +529,13 @@
       "    .\n",
       "\n",
       "DATA\n",
-      "    __version__ = '$Revision: $'\n",
       "    dprod = <fortran object>\n",
       "\n",
       "VERSION\n",
+      "    b'$Revision: $'\n",
       "\n",
+      "FILE\n",
+      "    /home/tig/KOsty/Prog/GitHub/scientific-python-lectures/dprod.cpython-36m-x86_64-linux-gnu.so\n",
       "\n",
       "\n"
      ]
@@ -574,7 +573,7 @@
     {
      "data": {
       "text/plain": [
-       "6.0828186403426752e+62"
+       "6.082818640342675e+62"
       ]
      },
      "execution_count": 15,
@@ -632,7 +631,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000000 loops, best of 3: 882 ns per loop\n"
+      "1.13 µs ± 14.3 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)\n"
      ]
     }
    ],
@@ -649,7 +648,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "100000 loops, best of 3: 4.45 µs per loop\n"
+      "2.72 µs ± 48.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)\n"
      ]
     }
    ],
@@ -750,8 +749,8 @@
       "\u001b[39mbuild_src\u001b[0m\n",
       "\u001b[39mbuilding extension \"dcumsum\" sources\u001b[0m\n",
       "\u001b[39mf2py options: []\u001b[0m\n",
-      "\u001b[39mf2py:> /tmp/tmpfvrMl6/src.linux-x86_64-2.7/dcumsummodule.c\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpfvrMl6/src.linux-x86_64-2.7\u001b[0m\n",
+      "\u001b[39mf2py:> /tmp/tmp751_c90c/src.linux-x86_64-3.6/dcumsummodule.c\u001b[0m\n",
+      "\u001b[39mcreating /tmp/tmp751_c90c/src.linux-x86_64-3.6\u001b[0m\n",
       "Reading fortran codes...\n",
       "\tReading file 'dcumsum.f' (format:fix,strict)\n",
       "Post-processing...\n",
@@ -762,56 +761,57 @@
       "\tBuilding module \"dcumsum\"...\n",
       "\t\tConstructing wrapper function \"dcumsum\"...\n",
       "\t\t  b = dcumsum(a)\n",
-      "\tWrote C/API module \"dcumsum\" to file \"/tmp/tmpfvrMl6/src.linux-x86_64-2.7/dcumsummodule.c\"\n",
-      "\u001b[39m  adding '/tmp/tmpfvrMl6/src.linux-x86_64-2.7/fortranobject.c' to sources.\u001b[0m\n",
-      "\u001b[39m  adding '/tmp/tmpfvrMl6/src.linux-x86_64-2.7' to include_dirs.\u001b[0m\n",
-      "\u001b[39mcopying /usr/lib/python2.7/dist-packages/numpy/f2py/src/fortranobject.c -> /tmp/tmpfvrMl6/src.linux-x86_64-2.7\u001b[0m\n",
-      "\u001b[39mcopying /usr/lib/python2.7/dist-packages/numpy/f2py/src/fortranobject.h -> /tmp/tmpfvrMl6/src.linux-x86_64-2.7\u001b[0m\n",
+      "\tWrote C/API module \"dcumsum\" to file \"/tmp/tmp751_c90c/src.linux-x86_64-3.6/dcumsummodule.c\"\n",
+      "\u001b[39m  adding '/tmp/tmp751_c90c/src.linux-x86_64-3.6/fortranobject.c' to sources.\u001b[0m\n",
+      "\u001b[39m  adding '/tmp/tmp751_c90c/src.linux-x86_64-3.6' to include_dirs.\u001b[0m\n",
+      "\u001b[39mcopying /usr/local/lib/python3.6/dist-packages/numpy/f2py/src/fortranobject.c -> /tmp/tmp751_c90c/src.linux-x86_64-3.6\u001b[0m\n",
+      "\u001b[39mcopying /usr/local/lib/python3.6/dist-packages/numpy/f2py/src/fortranobject.h -> /tmp/tmp751_c90c/src.linux-x86_64-3.6\u001b[0m\n",
       "\u001b[39mbuild_src: building npy-pkg config files\u001b[0m\n",
       "\u001b[39mrunning build_ext\u001b[0m\n",
       "\u001b[39mcustomize UnixCCompiler\u001b[0m\n",
       "\u001b[39mcustomize UnixCCompiler using build_ext\u001b[0m\n",
+      "\u001b[39mget_default_fcompiler: matching types: '['gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq', 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor']'\u001b[0m\n",
       "\u001b[39mcustomize Gnu95FCompiler\u001b[0m\n",
       "\u001b[39mFound executable /usr/bin/gfortran\u001b[0m\n",
       "\u001b[39mcustomize Gnu95FCompiler\u001b[0m\n",
       "\u001b[39mcustomize Gnu95FCompiler using build_ext\u001b[0m\n",
       "\u001b[39mbuilding 'dcumsum' extension\u001b[0m\n",
       "\u001b[39mcompiling C sources\u001b[0m\n",
-      "\u001b[39mC compiler: x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC\n",
+      "\u001b[39mC compiler: x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fdebug-prefix-map=/build/python3.6-sXpGnM/python3.6-3.6.3=. -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC\n",
       "\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpfvrMl6/tmp\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpfvrMl6/tmp/tmpfvrMl6\u001b[0m\n",
-      "\u001b[39mcreating /tmp/tmpfvrMl6/tmp/tmpfvrMl6/src.linux-x86_64-2.7\u001b[0m\n",
-      "\u001b[39mcompile options: '-I/tmp/tmpfvrMl6/src.linux-x86_64-2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/include/python2.7 -c'\u001b[0m\n",
-      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmpfvrMl6/src.linux-x86_64-2.7/dcumsummodule.c\u001b[0m\n",
-      "In file included from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarrayobject.h:17,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
-      "                 from /tmp/tmpfvrMl6/src.linux-x86_64-2.7/fortranobject.h:13,\n",
-      "                 from /tmp/tmpfvrMl6/src.linux-x86_64-2.7/dcumsummodule.c:18:\n",
-      "/usr/lib/python2.7/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
+      "\u001b[39mcreating /tmp/tmp751_c90c/tmp\u001b[0m\n",
+      "\u001b[39mcreating /tmp/tmp751_c90c/tmp/tmp751_c90c\u001b[0m\n",
+      "\u001b[39mcreating /tmp/tmp751_c90c/tmp/tmp751_c90c/src.linux-x86_64-3.6\u001b[0m\n",
+      "\u001b[39mcompile options: '-I/tmp/tmp751_c90c/src.linux-x86_64-3.6 -I/usr/local/lib/python3.6/dist-packages/numpy/core/include -I/usr/include/python3.6m -c'\u001b[0m\n",
+      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmp751_c90c/src.linux-x86_64-3.6/dcumsummodule.c\u001b[0m\n",
+      "In file included from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1816:0,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarrayobject.h:18,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
+      "                 from /tmp/tmp751_c90c/src.linux-x86_64-3.6/fortranobject.h:13,\n",
+      "                 from /tmp/tmp751_c90c/src.linux-x86_64-3.6/dcumsummodule.c:16:\n",
+      "/usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
       " #warning \"Using deprecated NumPy API, disable it by \" \\\n",
-      "  ^\n",
-      "/tmp/tmpfvrMl6/src.linux-x86_64-2.7/dcumsummodule.c:111:12: warning: ‘f2py_size’ defined but not used [-Wunused-function]\n",
+      "  ^~~~~~~\n",
+      "/tmp/tmp751_c90c/src.linux-x86_64-3.6/dcumsummodule.c:109:12: warning: ‘f2py_size’ defined but not used [-Wunused-function]\n",
       " static int f2py_size(PyArrayObject* var, ...)\n",
-      "            ^\n",
-      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmpfvrMl6/src.linux-x86_64-2.7/fortranobject.c\u001b[0m\n",
-      "In file included from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ndarrayobject.h:17,\n",
-      "                 from /usr/lib/python2.7/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
-      "                 from /tmp/tmpfvrMl6/src.linux-x86_64-2.7/fortranobject.h:13,\n",
-      "                 from /tmp/tmpfvrMl6/src.linux-x86_64-2.7/fortranobject.c:2:\n",
-      "/usr/lib/python2.7/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
+      "            ^~~~~~~~~\n",
+      "\u001b[39mx86_64-linux-gnu-gcc: /tmp/tmp751_c90c/src.linux-x86_64-3.6/fortranobject.c\u001b[0m\n",
+      "In file included from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1816:0,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/ndarrayobject.h:18,\n",
+      "                 from /usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/arrayobject.h:4,\n",
+      "                 from /tmp/tmp751_c90c/src.linux-x86_64-3.6/fortranobject.h:13,\n",
+      "                 from /tmp/tmp751_c90c/src.linux-x86_64-3.6/fortranobject.c:2:\n",
+      "/usr/local/lib/python3.6/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
       " #warning \"Using deprecated NumPy API, disable it by \" \\\n",
-      "  ^\n",
+      "  ^~~~~~~\n",
       "\u001b[39mcompiling Fortran sources\u001b[0m\n",
-      "\u001b[39mFortran f77 compiler: /usr/bin/gfortran -Wall -ffixed-form -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-      "Fortran f90 compiler: /usr/bin/gfortran -Wall -fno-second-underscore -fPIC -O3 -funroll-loops\n",
-      "Fortran fix compiler: /usr/bin/gfortran -Wall -ffixed-form -fno-second-underscore -Wall -fno-second-underscore -fPIC -O3 -funroll-loops\u001b[0m\n",
-      "\u001b[39mcompile options: '-I/tmp/tmpfvrMl6/src.linux-x86_64-2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/include/python2.7 -c'\u001b[0m\n",
+      "\u001b[39mFortran f77 compiler: /usr/bin/gfortran -Wall -g -ffixed-form -fno-second-underscore -fPIC -O3 -funroll-loops\n",
+      "Fortran f90 compiler: /usr/bin/gfortran -Wall -g -fno-second-underscore -fPIC -O3 -funroll-loops\n",
+      "Fortran fix compiler: /usr/bin/gfortran -Wall -g -ffixed-form -fno-second-underscore -Wall -g -fno-second-underscore -fPIC -O3 -funroll-loops\u001b[0m\n",
+      "\u001b[39mcompile options: '-I/tmp/tmp751_c90c/src.linux-x86_64-3.6 -I/usr/local/lib/python3.6/dist-packages/numpy/core/include -I/usr/include/python3.6m -c'\u001b[0m\n",
       "\u001b[39mgfortran:f77: dcumsum.f\u001b[0m\n",
-      "\u001b[39m/usr/bin/gfortran -Wall -Wall -shared /tmp/tmpfvrMl6/tmp/tmpfvrMl6/src.linux-x86_64-2.7/dcumsummodule.o /tmp/tmpfvrMl6/tmp/tmpfvrMl6/src.linux-x86_64-2.7/fortranobject.o /tmp/tmpfvrMl6/dcumsum.o -lgfortran -o ./dcumsum.so\u001b[0m\n",
-      "Removing build directory /tmp/tmpfvrMl6\n"
+      "\u001b[39m/usr/bin/gfortran -Wall -g -Wall -g -shared /tmp/tmp751_c90c/tmp/tmp751_c90c/src.linux-x86_64-3.6/dcumsummodule.o /tmp/tmp751_c90c/tmp/tmp751_c90c/src.linux-x86_64-3.6/fortranobject.o /tmp/tmp751_c90c/dcumsum.o -L/usr/lib/gcc/x86_64-linux-gnu/7 -L/usr/lib/gcc/x86_64-linux-gnu/7 -lgfortran -o ./dcumsum.cpython-36m-x86_64-linux-gnu.so\u001b[0m\n",
+      "Removing build directory /tmp/tmp751_c90c\n"
      ]
     }
    ],
@@ -845,7 +845,7 @@
     {
      "data": {
       "text/plain": [
-       "array([  1.,   3.,   6.,  10.,  15.,  21.,  28.,  36.])"
+       "array([ 1.,  3.,  6., 10., 15., 21., 28., 36.])"
       ]
      },
      "execution_count": 25,
@@ -865,7 +865,7 @@
     {
      "data": {
       "text/plain": [
-       "array([  1.,   3.,   6.,  10.,  15.,  21.,  28.,  36.])"
+       "array([ 1.,  3.,  6., 10., 15., 21., 28., 36.])"
       ]
      },
      "execution_count": 26,
@@ -885,7 +885,7 @@
     {
      "data": {
       "text/plain": [
-       "array([  1.,   3.,   6.,  10.,  15.,  21.,  28.,  36.])"
+       "array([ 1.,  3.,  6., 10., 15., 21., 28., 36.])"
       ]
      },
      "execution_count": 27,
@@ -895,6 +895,22 @@
    ],
    "source": [
     "cumsum(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Further reading"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. http://www.scipy.org/F2py\n",
+    "1. http://dsnra.jpl.nasa.gov/software/Python/F2PY_tutorial.pdf\n",
+    "1. http://www.shocksolution.com/2009/09/f2py-binding-fortran-python/"
    ]
   },
   {
@@ -968,7 +984,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "332 ms ± 17.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "325 ms ± 13.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -985,7 +1001,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.21 ms ± 119 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "2.92 ms ± 109 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -1002,7 +1018,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.49 ms ± 66.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "3.46 ms ± 83.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -1019,28 +1035,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.44 ms ± 101 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "2.34 ms ± 48.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
     "timeit py_dcumsum_jit(a)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Further reading"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "1. http://www.scipy.org/F2py\n",
-    "1. http://dsnra.jpl.nasa.gov/software/Python/F2PY_tutorial.pdf\n",
-    "1. http://www.shocksolution.com/2009/09/f2py-binding-fortran-python/"
    ]
   },
   {
@@ -1066,7 +1066,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1136,7 +1136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1153,14 +1153,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "libfunctions.so: ELF 64-bit LSB  shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=d68173ae6a804f703472af96f413b81a189db4b8, not stripped\r\n"
+      "libfunctions.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=90e86a83976f92495e705f77cf37a8098d896e60, not stripped\r\n"
      ]
     }
    ],
@@ -1177,7 +1177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -1223,7 +1223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -1244,7 +1244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -1263,7 +1263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1279,7 +1279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -1288,7 +1288,7 @@
        "120.0"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1306,7 +1306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1315,7 +1315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1324,7 +1324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1333,16 +1333,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([ 0.,  0.,  0., ...,  0.,  0.,  0.])"
+       "array([0., 0., 0., ..., 0., 0., 0.])"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1360,14 +1360,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000 loops, best of 3: 286 µs per loop\n"
+      "126 µs ± 1.93 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)\n"
      ]
     }
    ],
@@ -1377,14 +1377,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10000 loops, best of 3: 119 µs per loop\n"
+      "144 µs ± 1.48 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)\n"
      ]
     }
    ],
@@ -1394,14 +1394,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000 loops, best of 3: 261 µs per loop\n"
+      "329 µs ± 9.72 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
@@ -1440,7 +1440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -1473,7 +1473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
@@ -1499,7 +1499,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -1508,29 +1508,16 @@
      "text": [
       "running build_ext\n",
       "cythoning cy_dcumsum.pyx to cy_dcumsum.c\n",
-      "warning: /usr/local/lib/python2.7/dist-packages/Cython/Includes/numpy.pxd:869:17: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.\n",
-      "warning: /usr/local/lib/python2.7/dist-packages/Cython/Includes/numpy.pxd:869:24: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.\n",
       "building 'cy_dcumsum' extension\n",
-      "x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c cy_dcumsum.c -o build/temp.linux-x86_64-2.7/cy_dcumsum.o\n",
-      "In file included from /usr/include/python2.7/numpy/ndarraytypes.h:1761:0,\n",
-      "                 from /usr/include/python2.7/numpy/ndarrayobject.h:17,\n",
-      "                 from /usr/include/python2.7/numpy/arrayobject.h:4,\n",
-      "                 from cy_dcumsum.c:352:\n",
-      "/usr/include/python2.7/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [-Wcpp]\n",
-      " #warning \"Using deprecated NumPy API, disable it by \" \\\n",
-      "  ^\n",
-      "In file included from /usr/include/python2.7/numpy/ndarrayobject.h:26:0,\n",
-      "                 from /usr/include/python2.7/numpy/arrayobject.h:4,\n",
-      "                 from cy_dcumsum.c:352:\n",
-      "/usr/include/python2.7/numpy/__multiarray_api.h:1629:1: warning: ‘_import_array’ defined but not used [-Wunused-function]\n",
-      " _import_array(void)\n",
-      " ^\n",
-      "In file included from /usr/include/python2.7/numpy/ufuncobject.h:327:0,\n",
-      "                 from cy_dcumsum.c:353:\n",
-      "/usr/include/python2.7/numpy/__ufunc_api.h:241:1: warning: ‘_import_umath’ defined but not used [-Wunused-function]\n",
-      " _import_umath(void)\n",
-      " ^\n",
-      "x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -D_FORTIFY_SOURCE=2 -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security build/temp.linux-x86_64-2.7/cy_dcumsum.o -o /home/rob/Desktop/scientific-python-lectures/cy_dcumsum.so\n"
+      "x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fdebug-prefix-map=/build/python3.6-sXpGnM/python3.6-3.6.3=. -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.6m -c cy_dcumsum.c -o build/temp.linux-x86_64-3.6/cy_dcumsum.o\n",
+      "In file included from \u001b[01m\u001b[K/usr/include/numpy/ndarraytypes.h:1788:0\u001b[m\u001b[K,\n",
+      "                 from \u001b[01m\u001b[K/usr/include/numpy/ndarrayobject.h:18\u001b[m\u001b[K,\n",
+      "                 from \u001b[01m\u001b[K/usr/include/numpy/arrayobject.h:4\u001b[m\u001b[K,\n",
+      "                 from \u001b[01m\u001b[Kcy_dcumsum.c:525\u001b[m\u001b[K:\n",
+      "\u001b[01m\u001b[K/usr/include/numpy/npy_1_7_deprecated_api.h:15:2:\u001b[m\u001b[K \u001b[01;35m\u001b[Kwarning: \u001b[m\u001b[K#warning \"Using deprecated NumPy API, disable it by \" \"#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION\" [\u001b[01;35m\u001b[K-Wcpp\u001b[m\u001b[K]\n",
+      " #\u001b[01;35m\u001b[Kwarning\u001b[m\u001b[K \"Using deprecated NumPy API, disable it by \" \\\n",
+      "  \u001b[01;35m\u001b[K^~~~~~~\u001b[m\u001b[K\n",
+      "x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -specs=/usr/share/dpkg/no-pie-link.specs -Wl,-z,relro -Wl,-Bsymbolic-functions -specs=/usr/share/dpkg/no-pie-link.specs -Wl,-z,relro -g -fdebug-prefix-map=/build/python3.6-sXpGnM/python3.6-3.6.3=. -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.6/cy_dcumsum.o -o /home/tig/KOsty/Prog/GitHub/scientific-python-lectures/cy_dcumsum.cpython-36m-x86_64-linux-gnu.so\n"
      ]
     }
    ],
@@ -1540,7 +1527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1549,16 +1536,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([  1.,   3.,   6.,  10.])"
+       "array([ 1.,  3.,  6., 10.])"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1572,7 +1559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1581,16 +1568,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([  1.,   3.,   6.,  10.,  15.,  21.,  28.,  36.])"
+       "array([ 1.,  3.,  6., 10., 15., 21., 28., 36.])"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1603,16 +1590,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([  1.,   3.,   6.,  10.,  15.,  21.,  28.,  36.])"
+       "array([ 1.,  3.,  6., 10., 15., 21., 28., 36.])"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1623,7 +1610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1633,14 +1620,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 50.1 ms per loop\n"
+      "32.5 ms ± 1.67 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1650,14 +1637,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000 loops, best of 3: 263 µs per loop\n"
+      "328 µs ± 8.02 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
@@ -1676,16 +1663,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When working with the IPython (especially in the notebook), there is a more convenient way of compiling and loading Cython code. Using the `%%cython` IPython magic (command to IPython), we can simply type the Cython code in a code cell and let IPython take care of the conversion to C code, compilation and loading of the function. To be able to use the `%%cython` magic, we first need to load the extension `cythonmagic`:"
+    "When working with the IPython (especially in the notebook), there is a more convenient way of compiling and loading Cython code. Using the `%%cython` IPython magic (command to IPython), we can simply type the Cython code in a code cell and let IPython take care of the conversion to C code, compilation and loading of the function. To be able to use the `%%cython` magic, we first need to load the extension `cython`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext cythonmagic"
+    "%load_ext cython"
    ]
   },
   {
@@ -1715,7 +1702,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000 loops, best of 3: 265 µs per loop\n"
+      "330 µs ± 8.47 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
@@ -1757,15 +1744,15 @@
        "Software versions": [
         {
          "module": "Python",
-         "version": "2.7.6 (default, Mar 22 2014, 22:59:56) [GCC 4.8.2]"
+         "version": "3.6.3 64bit [GCC 7.2.0]"
         },
         {
          "module": "IPython",
-         "version": "1.1.0"
+         "version": "6.2.1"
         },
         {
          "module": "OS",
-         "version": "posix [linux2]"
+         "version": "Linux 4.13.0 36 generic x86_64 with Ubuntu 17.10 artful"
         },
         {
          "module": "ctypes",
@@ -1773,35 +1760,32 @@
         },
         {
          "module": "Cython",
-         "version": "0.20.2"
+         "version": "0.27.3"
         }
        ]
       },
       "text/html": [
-       "<table><tr><th>Software</th><th>Version</th></tr><tr><td>Python</td><td>2.7.6 (default, Mar 22 2014, 22:59:56) [GCC 4.8.2]</td></tr><tr><td>IPython</td><td>1.1.0</td></tr><tr><td>OS</td><td>posix [linux2]</td></tr><tr><td>ctypes</td><td>1.1.0</td></tr><tr><td>Cython</td><td>0.20.2</td></tr><tr><td colspan='2'>Tue Aug 26 23:37:29 2014 JST</td></tr></table>"
+       "<table><tr><th>Software</th><th>Version</th></tr><tr><td>Python</td><td>3.6.3 64bit [GCC 7.2.0]</td></tr><tr><td>IPython</td><td>6.2.1</td></tr><tr><td>OS</td><td>Linux 4.13.0 36 generic x86_64 with Ubuntu 17.10 artful</td></tr><tr><td>ctypes</td><td>1.1.0</td></tr><tr><td>Cython</td><td>0.27.3</td></tr><tr><td colspan='2'>Tue Feb 27 21:47:05 2018 MSK</td></tr></table>"
       ],
       "text/latex": [
-       "\\begin{table}\n",
        "\\begin{tabular}{|l|l|}\\hline\n",
        "{\\bf Software} & {\\bf Version} \\\\ \\hline\\hline\n",
-       "Python & 2.7.6 (default, Mar 22 2014, 22:59:56) [GCC 4.8.2] \\\\ \\hline\n",
-       "IPython & 1.1.0 \\\\ \\hline\n",
-       "OS & posix [linux2] \\\\ \\hline\n",
+       "Python & 3.6.3 64bit [GCC 7.2.0] \\\\ \\hline\n",
+       "IPython & 6.2.1 \\\\ \\hline\n",
+       "OS & Linux 4.13.0 36 generic x86\\_64 with Ubuntu 17.10 artful \\\\ \\hline\n",
        "ctypes & 1.1.0 \\\\ \\hline\n",
-       "Cython & 0.20.2 \\\\ \\hline\n",
-       "\\hline \\multicolumn{2}{|l|}{Tue Aug 26 23:37:29 2014 JST} \\\\ \\hline\n",
-       "\\end{tabular}\n",
-       "\\end{table}\n"
+       "Cython & 0.27.3 \\\\ \\hline\n",
+       "\\hline \\multicolumn{2}{|l|}{Tue Feb 27 21:47:05 2018 MSK} \\\\ \\hline\n",
+       "\\end{tabular}\n"
       ],
       "text/plain": [
        "Software versions\n",
-       "Python 2.7.6 (default, Mar 22 2014, 22:59:56) [GCC 4.8.2]\n",
-       "IPython 1.1.0\n",
-       "OS posix [linux2]\n",
+       "Python 3.6.3 64bit [GCC 7.2.0]\n",
+       "IPython 6.2.1\n",
+       "OS Linux 4.13.0 36 generic x86_64 with Ubuntu 17.10 artful\n",
        "ctypes 1.1.0\n",
-       "Cython 0.20.2\n",
-       "\n",
-       "Tue Aug 26 23:37:29 2014 JST"
+       "Cython 0.27.3\n",
+       "Tue Feb 27 21:47:05 2018 MSK"
       ]
      },
      "execution_count": 64,

--- a/Lecture-6A-Fortran-Numba-and-C.ipynb
+++ b/Lecture-6A-Fortran-Numba-and-C.ipynb
@@ -901,7 +901,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Benchmark the different implementations:"
+    "## Numba\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Numba is an LLVM compiler for Python which can be used as a regular module. It compiles Python code just-in-time (JIT) of program execution. You can use it as a decorator or call it explicitly. Usage example:"
    ]
   },
   {
@@ -910,41 +917,46 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "a = rand(10000)"
+    "import numba\n",
+    "@numba.jit\n",
+    "def some_func(a,b):\n",
+    "    return a+b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Numba is mostly useful for direct coding of heavy computations without the use of Python constructs like tuples or dicts. However, it is aware of NumPy arrays and can nicely interoperate with them. Moreover, it is possible to simplify some general function from NumPy and SciPy to your exact case and gain a several times speedup. So this is an obvious option to do heavy lifting directly in Python without writing a line of code in Fortran or C.\n",
+    "\n",
+    "Note, that a productive way is to use some function readily available in NumPy, SciPy, or some other library. Write your own code only when there is no other option. You can also use Numba after you have some working code and you need to do some speed optimization.\n",
+    "\n",
+    "To ensure the performance mode you should pass a nopython option to Numba. For many other possible options refer to [Numba documentation](http://numba.pydata.org/numba-doc/latest/index.html)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 29,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 loops, best of 3: 4.83 ms per loop\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "timeit py_dcumsum(a)"
+    "py_dcumsum_jit = numba.jit(nopython=True)(py_dcumsum)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Benchmark the different implementations:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 30,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100000 loops, best of 3: 12.2 µs per loop\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "timeit dcumsum.dcumsum(a)"
+    "a = rand(10**6)"
    ]
   },
   {
@@ -956,12 +968,63 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10000 loops, best of 3: 27.4 µs per loop\n"
+      "332 ms ± 17.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "timeit py_dcumsum(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.21 ms ± 119 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "timeit dcumsum.dcumsum(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.49 ms ± 66.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
    "source": [
     "timeit a.cumsum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.44 ms ± 101 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "timeit py_dcumsum_jit(a)"
    ]
   },
   {

--- a/Lecture-6A-Fortran-Numba-and-C.ipynb
+++ b/Lecture-6A-Fortran-Numba-and-C.ipynb
@@ -21,9 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -52,9 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -105,9 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -139,9 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -232,9 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -254,9 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -286,9 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -315,9 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -391,9 +375,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -426,9 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -522,9 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import dprod"
@@ -533,9 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -573,9 +549,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -595,9 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -618,9 +590,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -647,9 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "xvec = rand(500)"
@@ -658,9 +626,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -677,9 +643,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -710,9 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# simple python algorithm: example of a SLOW implementation\n",
@@ -735,9 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -775,9 +735,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -864,9 +822,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import dcumsum"
@@ -875,9 +831,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "a = array([1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0])"
@@ -886,9 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -908,9 +860,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -930,9 +880,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -959,9 +907,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "a = rand(10000)"
@@ -970,9 +916,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -989,9 +933,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1008,9 +950,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1064,9 +1004,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1136,9 +1074,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!gcc -c -Wall -O2 -Wall -ansi -pedantic -fPIC -o functions.o functions.c\n",
@@ -1155,9 +1091,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1181,9 +1115,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1229,9 +1161,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1252,9 +1182,7 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1273,9 +1201,7 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import functions"
@@ -1291,9 +1217,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1320,9 +1244,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "a = rand(100000)"
@@ -1331,9 +1253,7 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "res_c = functions.dcumsum(a, len(a)) "
@@ -1342,9 +1262,7 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "res_fortran = dcumsum.dcumsum(a)"
@@ -1353,9 +1271,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1382,9 +1298,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1401,9 +1315,7 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1420,9 +1332,7 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1468,9 +1378,7 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1503,9 +1411,7 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1531,9 +1437,7 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1574,9 +1478,7 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import cy_dcumsum"
@@ -1585,9 +1487,7 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1610,9 +1510,7 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "a = array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])"
@@ -1621,9 +1519,7 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1645,9 +1541,7 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1667,9 +1561,7 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "a = rand(100000)\n",
@@ -1679,9 +1571,7 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1698,9 +1588,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1731,9 +1619,7 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%load_ext cythonmagic"
@@ -1742,9 +1628,7 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%cython\n",
@@ -1762,9 +1646,7 @@
   {
    "cell_type": "code",
    "execution_count": 63,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1804,9 +1686,7 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1875,23 +1755,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Add a Numba example. For scientific computing, it provides similar performance compared to Cython, however, it is probably more practical in real life. Actually, I was surprised to  see a better performance from Numba compared to Fortran module (2.92 ms vs 2.34 ms).