### PR TITLE
Fix deprecated features in Lecture-4-Matplotlib.ipynb

### DIFF
--- a/Lecture-4-Matplotlib.ipynb
+++ b/Lecture-4-Matplotlib.ipynb
@@ -4312,7 +4312,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Matplotlib has a number of \"backends\" which are responsible for rendering graphs. The different backends are able to generate graphics with different formats and display/event loops. There is a distinction between noninteractive backends (such as 'agg', 'svg', 'pdf', etc.) that are only used to generate image files (e.g. with the `savefig` function), and interactive backends (such as Qt4Agg, GTK, MaxOSX) that can display a GUI window for interactively exploring figures. \n",
+    "Matplotlib has a number of \"backends\" which are responsible for rendering graphs. The different backends are able to generate graphics with different formats and display/event loops. There is a distinction between noninteractive backends (such as 'agg', 'svg', 'pdf', etc.) that are only used to generate image files (e.g. with the `savefig` function), and interactive backends (such as qtagg, GTK, MaxOSX) that can display a GUI window for interactively exploring figures. \n",
     "\n",
     "A list of available backends are:"
    ]
@@ -4328,7 +4328,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[u'GTK', u'GTKAgg', u'GTKCairo', u'MacOSX', u'Qt4Agg', u'Qt5Agg', u'TkAgg', u'WX', u'WXAgg', u'CocoaAgg', u'GTK3Cairo', u'GTK3Agg', u'WebAgg', u'nbAgg', u'agg', u'cairo', u'emf', u'gdk', u'pdf', u'pgf', u'ps', u'svg', u'template']\n"
+      "[u'GTK', u'GTKAgg', u'GTKCairo', u'MacOSX', u'qtagg', u'Qt5Agg', u'TkAgg', u'WX', u'WXAgg', u'CocoaAgg', u'GTK3Cairo', u'GTK3Agg', u'WebAgg', u'nbAgg', u'agg', u'cairo', u'emf', u'gdk', u'pdf', u'pgf', u'ps', u'svg', u'template']\n"
      ]
     }
    ],
@@ -4520,7 +4520,7 @@
     "# (e.g. Kernel > Restart)\n",
     "# \n",
     "import matplotlib\n",
-    "matplotlib.use('Qt4Agg') # or for example MacOSX\n",
+    "matplotlib.use('qtagg') # or for example MacOSX\n",
     "import matplotlib.pylab as plt\n",
     "import numpy as np"
    ]
@@ -4533,7 +4533,7 @@
    },
    "outputs": [],
    "source": [
-    "# Now, open an interactive plot window with the Qt4Agg backend\n",
+    "# Now, open an interactive plot window with the qtagg backend\n",
     "fig, ax = plt.subplots()\n",
     "t = np.linspace(0, 10, 100)\n",
     "ax.plot(t, np.cos(t) * np.sin(t))\n",

--- a/Lecture-4-Matplotlib.ipynb
+++ b/Lecture-4-Matplotlib.ipynb
@@ -4641,8 +4641,8 @@
     }
    ],
    "source": [
-    "%reload_ext version_information\n",
-    "%version_information numpy, scipy, matplotlib"
+    "%reload_ext watermark\n",
+    "%watermark -v -p numpy,scipy,matplotlib"
    ]
   }
  ],

--- a/Lecture-4-Matplotlib.ipynb
+++ b/Lecture-4-Matplotlib.ipynb
@@ -4333,7 +4333,7 @@
     }
    ],
    "source": [
-    "print(matplotlib.rcsetup.all_backends)"
+    "print(matplotlib.backends.backend_registry.list_builtin())"
    ]
   },
   {


### PR DESCRIPTION
1. The `all_backends` attribute was deprecated in Matplotlib 3.9 and will be removed in 3.11. Use `matplotlib.backends.backend_registry.list_builtin()` instead.
2.  Replace deprecated (transitively) package "version_information" with "watermark".
3. Replace deprecated "Qt4Agg" with "qtagg".